### PR TITLE
Add resource types jobs, cronjobs and replicasets

### DIFF
--- a/deploy/controller/webhook.yaml
+++ b/deploy/controller/webhook.yaml
@@ -10,6 +10,12 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["*"]
         scope: "*"
+    namespaceSelector:
+      matchExpressions:
+      - key: name
+        operator: NotIn
+        values: ["kube-system", "kube-public", "kube-node-lease", "default"]
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: validate-registry


### PR DESCRIPTION
This PR adds other resource types such as jobs, cronjobs and replicasets. 
Default case is still kept. I also thought that, excluding namespaces like kube-system by default would be really helpful. It can break the cluster in some scenario when high availability cluster is configured and this controller, launches before another control plane node has joined the cluster. 