### PR TITLE
Update for adding e2e tests for job, crondjob and replicaset

### DIFF
--- a/e2e-test/fail-scenario/cronjob-with-non-allowed-repo.yaml
+++ b/e2e-test/fail-scenario/cronjob-with-non-allowed-repo.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: bad-cronjob
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: test
+            image: docker.io/nginx:latest
+            command: ["echo", "hello"]
+          restartPolicy: OnFailure

--- a/e2e-test/fail-scenario/job-with-non-allowed-repo.yaml
+++ b/e2e-test/fail-scenario/job-with-non-allowed-repo.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bad-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: docker.io/nginx:latest
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/e2e-test/fail-scenario/rs-with-non-allowed-repo.yaml
+++ b/e2e-test/fail-scenario/rs-with-non-allowed-repo.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: bad-rs
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5

--- a/e2e-test/pass-scenario/cronjob-with-allowed-repo.yaml
+++ b/e2e-test/pass-scenario/cronjob-with-allowed-repo.yaml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: good-cronjob
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: test
+            image: registry.kupher.io/nginx:latest
+            command: ["echo", "hello"]
+          restartPolicy: OnFailure

--- a/e2e-test/pass-scenario/job-with-allowed-repo.yaml
+++ b/e2e-test/pass-scenario/job-with-allowed-repo.yaml
@@ -1,0 +1,13 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: good-job
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        image: registry.kupher.io/nginx:latest
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/e2e-test/pass-scenario/rs-with-allowed-repo.yaml
+++ b/e2e-test/pass-scenario/rs-with-allowed-repo.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: good-rs
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      tier: frontend
+  template:
+    metadata:
+      labels:
+        tier: frontend
+    spec:
+      containers:
+      - name: nginx
+        image: registry.kupher.io/nginx:latest


### PR DESCRIPTION
This PR adds e2e tests for three kinds of kubernetes resources: Jobs, CronJobs and ReplicaSets.
It has one test for each failure and pass scenario. 